### PR TITLE
Dell XPS post correction: crypsetup defaults to luks2 header since a while specify v1 on the key partition

### DIFF
--- a/_posts/2017-05-15-nixos-on-dell-9560.markdown
+++ b/_posts/2017-05-15-nixos-on-dell-9560.markdown
@@ -169,7 +169,7 @@ Then:
 # Create an encrypted disk to hold our key, the key to this drive
 # is what you'll type in to unlock the rest of your drives... so,
 # remember it:
-$ cryptsetup luksFormat /dev/nvme0n1p2
+$ cryptsetup luksFormat --type luks1 /dev/nvme0n1p2
 $ cryptsetup luksOpen /dev/nvme0n1p2 cryptkey
 
 # Fill our key disk with random data, wihch will be our key:


### PR DESCRIPTION
Since crypsetup was updated in nixpkgs the default format is LUKSv2 which needs 16MiB in space for the header.

This change just ensures that the partition layout you are proposing keeps working on newer NixOS versions. There shouldn't be any real downside (for most users).