### PR TITLE
Update 2020-04-13-erase-your-darlings.md

### DIFF
--- a/_posts/2020-04-13-erase-your-darlings.md
+++ b/_posts/2020-04-13-erase-your-darlings.md
@@ -273,11 +273,11 @@ directory:
     enable = true;
     hostKeys = [
       {
-        path = "/persist/ssh/ssh_host_ed25519_key";
+        path = "/persist/etc/ssh/ssh_host_ed25519_key";
         type = "ed25519";
       }
       {
-        path = "/persist/ssh/ssh_host_rsa_key";
+        path = "/persist/etc/ssh/ssh_host_rsa_key";
         type = "rsa";
         bits = 4096;
       }


### PR DESCRIPTION
Fix ssh certificate path in example.

Since the mkdir is create /persist/etc/ssh The path to the ssh certificate needs the /etc part as well